### PR TITLE
Fix group title render order on mouse hover

### DIFF
--- a/src/view/TimeSpanView.cpp
+++ b/src/view/TimeSpanView.cpp
@@ -75,6 +75,7 @@ static _<AView> dayContent(
         return hash;
     };
     auto toGroups =
+        ranges::view::reverse |
         ranges::view::filter(intersectsWithDay) |
         ranges::view::transform([=](const _<TimeSpan>& span) { return groupify(state->database, *span); }) |
         ranges::view::chunk_by([](const TimeSpanViewModel& a, const TimeSpanViewModel& b) {


### PR DESCRIPTION
Swaps the order in which groups are added, so groups that are "higher" are effectively rendered on top of "lower" ones:

<img width="147" height="105" alt="image" src="https://github.com/user-attachments/assets/ec90ead6-7d75-4de4-a5c0-412f85f1260d" />

Which makes titles somewhat readable within dense spans.